### PR TITLE
Feature/PA-349 Create interactive plots

### DIFF
--- a/R/likert_labelled.R
+++ b/R/likert_labelled.R
@@ -9,12 +9,12 @@ likert_labelled <- function(ds, mid_level, ranked_levels, group,
   #' The main function for the \code{\link{precisionlikert}} package.
   #'
   #' @param ds a datafarme with groups as rows and levels as columns
-  #' @param ranked_levels an ordered factor of all levels
-  #' @param mid_ldevel the neutral or middle category
-  #' @param group a factor or character vector of all groups (y-axis of likert plot)
-  #' @param label_minimum the proportion for which likert plot will be labelled
-  #' @param group_arrange a character of positive (default) or negative
-  #' @param cat_neutral default TRUE but if FALSE then there is no true neutral category; mid_level specifies where alignment will happen
+  #' @param ranked_levels an character vector of Likert levels, in desired order
+  #' @param mid_level the neutral or middle category of the scale
+  #' @param group a character giving name of grouping variable (y-axis of likert plot)
+  #' @param label_minimum the minimum proportion for which likert plot will be labelled
+  #' @param group_arrange a string, either "positive" (default) or "negative" to indicate vertical arrangement of groups within the plot
+  #' @param cat_neutral logical; default TRUE. If FALSE then there is no true neutral category; mid_level specifies where alignment will happen
   #' @return None
   #' @examples
   #' data("country_outlook")
@@ -27,89 +27,82 @@ likert_labelled <- function(ds, mid_level, ranked_levels, group,
 
   #---------- Separates the positive and negative responses based on mid-level category ----------#
 
-  if(cat_neutral) {
+  if (cat_neutral) {
     ds[ , mid_level] <- ds[ , mid_level]/2
-    upper_levels <- which(colnames(ds)==mid_level):which(colnames(ds)==last(ranked_levels) )
-    lower_levels <- which(colnames(ds)==first(ranked_levels)):which(colnames(ds)==mid_level)
+
   }
 
-  if(!cat_neutral) {
-    #ds[ , mid_level] <- ds[ , mid_level]/2
-    upper_levels <- which(colnames(ds)==mid_level):which(colnames(ds)==last(ranked_levels) )
-    lower_levels <- which(colnames(ds)==first(ranked_levels)):(which(colnames(ds)==mid_level) - 1)
+  upper_levels_indices <- match(mid_level, colnames(ds)) : match(last(ranked_levels), colnames(ds))
+
+  lower_levels_indices <- if (cat_neutral) {
+    match(first(ranked_levels), colnames(ds)) : match(mid_level, colnames(ds))
+  } else {
+    match(first(ranked_levels), colnames(ds)) : (match(mid_level, colnames(ds)) - 1)
   }
 
   #---------- Orders by group and by categories ----------#
 
-  ds_upper <- ds %>% select(!!group, upper_levels) %>%
-    gather(variable, value, -!!group, factor_key = TRUE)
+  ds_rank_columns <- switch(group_arrange,
+                            positive = upper_levels_indices,
+                            negative = lower_levels_indices
+  )
 
-  ds_lower <- ds %>% select(!!group, lower_levels) %>%
-    gather(variable, value, -!!group, factor_key = TRUE)
-
-  ds_upper$variable <- fct_rev(ds_upper$variable)
-
-  if(group_arrange == "positive") {
-    ds$sum_for_rank <- rowSums(ds[ ,upper_levels])
-  }
-  if(group_arrange == "negative") {
-    ds$sum_for_rank <- rowSums(ds[ ,lower_levels])
-  }
+  ds$sum_for_rank <- rowSums(ds[ ,ds_rank_columns])
 
   group_order <- ds %>% arrange(sum_for_rank) %>% pull(!!group)
+
+  ds_upper <- ds %>% select(!!group, upper_levels_indices) %>%
+    gather(variable, value, -!!group, factor_key = TRUE) %>%
+    mutate(variable = fct_rev(variable))
+
+  ds_lower <- ds %>% select(!!group, lower_levels_indices) %>%
+    gather(variable, value, -!!group, factor_key = TRUE)
+
   ds_upper[ , group] <- factor(ds_upper[ , group], levels = group_order)
   ds_lower[ , group] <- factor(ds_lower[ , group], levels = group_order)
-
-  names_lower_levels <- colnames(ds[ ,lower_levels])
-  names_upper_levels <- colnames(ds[ ,upper_levels])
-
 
 
   #---------- Calculates the relative label positions ----------#
 
   n_lags <- 1:floor(length(ranked_levels)/2)
+  max_digits <- nchar(max(n_lags))
+  lag_names <- sprintf("lag%0*d", max_digits, n_lags)
+  lag_functions <- setNames(sprintf("dplyr::lag(., %d, default = 0)", n_lags), lag_names)
 
-  lag_names <- paste("lag", formatC(n_lags, width = nchar(max(n_lags)),
-                                    flag = "0"), sep = "")
 
-  lag_functions <- setNames(paste("dplyr::lag(., ", n_lags, ', default=0',")"), lag_names)
+  ds_labels_upper <- ds_upper %>%
+    group_by(!!sym(group)) %>%
+    mutate_at(vars(value), funs_(lag_functions)) %>%
+    ungroup() %>%
+    mutate(pos  = value/2 + rowSums(select(., contains("lag"))))
 
-  if(cat_neutral) {
+  ds_labels_lower <-  ds_lower %>%
+    arrange(desc(variable)) %>%
+    group_by(!!sym(group))  %>%
+    mutate_at(vars(value), funs_(lag_functions)) %>%
+    ungroup() %>%
+    mutate(pos  = 0 - (value/2 + rowSums(select(., contains("lag")))))
 
-    ds_labels_upper <- ds_upper %>% group_by(!!sym(group)) %>%
-      mutate_at(vars(value), funs_(lag_functions)) %>%
-      ungroup() %>%
-      mutate(pos  = value/2 + rowSums(select(., contains("lag")))) %>%
-      mutate(pos = ifelse(variable == mid_level, 0, pos))
+  if (cat_neutral) {
 
-    ds_labels_lower <-  ds_lower %>% arrange(desc(variable)) %>% group_by(!!sym(group))  %>%
-      mutate_at(vars(value), funs_(lag_functions)) %>%
-      ungroup() %>%
-      mutate(pos  = 0 - (value/2 + rowSums(select(., contains("lag"))))) %>%
-      mutate(pos = ifelse(variable == mid_level, 0, pos))
+    ds_labels_upper <- ds_labels_upper %>%
+      mutate(pos = ifelse(variable == mid_level, 0, pos),
+             value = ifelse(variable == mid_level, value*2, value))
 
-    ds_labels <- rbind(ds_labels_lower, ds_labels_upper) %>% distinct() %>%
-      mutate(value = ifelse(variable == mid_level, value*2, value)) %>%
+    ds_labels_lower <-  ds_labels_lower %>%
+      mutate(pos = ifelse(variable == mid_level, 0, pos),
+             value = ifelse(variable == mid_level, value*2, value)) %>%
+      arrange(variable)
+
+    ds_labels <- rbind(ds_labels_lower, ds_labels_upper) %>%
+      distinct() %>%
       filter(value >= label_minimum)
   }
 
+  if (!cat_neutral) {
 
-  if(!cat_neutral) {
-
-    ds_labels_upper <- ds_upper %>% group_by(!!sym(group)) %>%
-      mutate_at(vars(value), funs_(lag_functions)) %>%
-      ungroup() %>%
-      mutate(pos  = value/2 + rowSums(select(., contains("lag")))) #%>%
-    #mutate(pos = ifelse(variable == mid_level, 0, pos))
-
-    ds_labels_lower <-  ds_lower %>% arrange(desc(variable)) %>% group_by(!!sym(group))  %>%
-      mutate_at(vars(value), funs_(lag_functions)) %>%
-      ungroup() %>%
-      mutate(pos  = 0 - (value/2 + rowSums(select(., contains("lag"))))) #%>%
-    #mutate(pos = ifelse(variable == mid_level, 0, pos))
-
-    ds_labels <- rbind(ds_labels_lower, ds_labels_upper) %>% distinct() %>%
-      #mutate(value = ifelse(variable == mid_level, value*2, value)) %>%
+    ds_labels <- rbind(ds_labels_lower, ds_labels_upper) %>%
+      distinct() %>%
       filter(value >= label_minimum)
   }
 
@@ -122,19 +115,23 @@ likert_labelled <- function(ds, mid_level, ranked_levels, group,
 
   #---------- Produce the plot ----------#
 
-  g <- ggplot() +
-    geom_bar(data = ds_lower, aes(x = !!sym(group), y = -value, fill = variable),
-             position="stack", stat="identity") +
-    geom_bar(data = ds_upper, aes(x = !!sym(group), y = value, fill = variable),
-             position="stack", stat="identity") +
-    coord_flip() + theme_fivethirtyeight() +
-    geom_hline(yintercept = 0, color =c("white"))  +
-    scale_fill_manual(values = likert_pal,
-                      breaks = ranked_levels,
-                      name = '') +
-    geom_text(aes(label =  sprintf("%.2f", value), x = !!sym(group), y = pos), data = ds_labels)
+      g <- ggplot() +
+      geom_bar(data = ds_lower, aes(x = get(group), y = -value, fill = variable),
+               position = "stack", stat = "identity") +
+      geom_bar(data = ds_upper, aes(x = get(group), y = value, fill = variable),
+               position = "stack", stat = "identity") +
+      coord_flip() +
+      geom_hline(yintercept = 0, color = c("white"))  +
+      scale_fill_manual(values = likert_pal, breaks = ranked_levels, name = '') +
+      geom_text(data = ds_labels, aes(label =  sprintf("%.2f", value), x = get(group), y = pos)) +
+      theme_minimal() +
+      theme(legend.position = "bottom",
+            panel.grid.major = element_blank(),
+            panel.grid.minor = element_blank()) +
+      labs(x = "", y = "")
 
   return(g)
+
 }
 
 

--- a/R/likert_labelled.R
+++ b/R/likert_labelled.R
@@ -2,7 +2,7 @@
 
 likert_labelled <- function(ds, mid_level, ranked_levels, group,
                             label_minimum = 0.05, group_arrange = 'positive',
-                            cat_neutral = TRUE) {
+                            cat_neutral = TRUE, interactive = FALSE) {
 
   #' Produces likert plots with labels
   #'
@@ -115,7 +115,40 @@ likert_labelled <- function(ds, mid_level, ranked_levels, group,
 
   #---------- Produce the plot ----------#
 
-      g <- ggplot() +
+  if (interactive) {
+    g1 <- plot_ly(type = "bar", data = ds_lower, x = ~-value, y = ~get(group), color = ~fct_rev(variable),
+                  colors = likert_pal, orientation = "h", legendgroup = ~variable,
+                  text = sprintf("%s: %s <br>Level: %s <br>Proportion: %.2f",
+                                 group,
+                                 ds_labels_lower[[group]],
+                                 ds_labels_lower$variable,
+                                 ds_labels_lower$value),
+                  hoverinfo = "text") %>%
+      layout(barmode = "stack",
+             xaxis = list(title = ""))
+
+    g2 <- plot_ly(type = "bar", data = ds_upper, x = ~value, y = ~get(group), color = ~fct_rev(variable),
+                  colors = likert_pal, orientation = "h", legendgroup = ~variable,
+                  text = sprintf("%s: %s <br>Level: %s <br>Proportion: %.2f",
+                                 group,
+                                 ds_labels_upper[[group]],
+                                 ds_labels_upper$variable,
+                                 ds_labels_upper$value),
+                  hoverinfo = "text") %>%
+      layout(barmode = "stack",
+             legend = list(orientation = "h"),
+             xaxis = list(title = "",
+                          zeroline = FALSE))
+
+
+
+    g <- subplot(g1, g2, shareY = TRUE, shareX = TRUE, margin = 0) %>%
+      layout(yaxis = list(title = ""))
+  }
+
+
+  if (!interactive) {
+    g <- ggplot() +
       geom_bar(data = ds_lower, aes(x = get(group), y = -value, fill = variable),
                position = "stack", stat = "identity") +
       geom_bar(data = ds_upper, aes(x = get(group), y = value, fill = variable),
@@ -129,6 +162,7 @@ likert_labelled <- function(ds, mid_level, ranked_levels, group,
             panel.grid.major = element_blank(),
             panel.grid.minor = element_blank()) +
       labs(x = "", y = "")
+  }
 
   return(g)
 


### PR DESCRIPTION
The ability to create an interactive plot based on the plotly package was added to the `likert_labelled` function. I had to make a plot for the lower likert values and another for the upper likert values and use `subplot` to combine them to get the desired output. Attempting to add the lower and upper stacked bar in one plot resulted in errors. 

Note that the legend in the plotly object continues to be an issue both in ordering and in including an additional category when `cat_neutal` is TRUE. 

I didn't include the calls to the libraries necessary to run the `likert_labelled` function because I was unsure of where to put them. Currently, this function requires `ggplot2`, `plotly`, `forecats`, `tidyr` and `dplyr`.

The code has also cleaned up, removing some redundancies and unused portions of code. Other changes include converting `if` statement conditions away from the `if (x == 1)` format to `if (identical(x, 1))` syntax. Unfortunately, I have not been able to update the `mutate_at` syntax to the new `dplyr` version given the current method of creating lags for calculating label position. 
